### PR TITLE
Improve `pytest.raises` assertions

### DIFF
--- a/tests/test_syx.py
+++ b/tests/test_syx.py
@@ -66,7 +66,11 @@ def test_hasattr():
     assert hasattr(GoesBoom(), 'ok')
     assert hasattr(GoesBoom(), 'dynamic')
     assert not hasattr(GoesBoom(), 'bar')
-    with pytest.raises(Exception, message='Oh Noes!'):
+    with pytest.raises(Exception) as excinfo:
         hasattr(GoesBoom(), 'foo')
-    with pytest.raises(Exception, message='boom'):
+    msg, = excinfo.value.args
+    assert msg == 'Oh Noes!'
+    with pytest.raises(Exception) as excinfo:
         hasattr(GoesBoom(), 'boom')
+    msg, = excinfo.value.args
+    assert msg == 'boom'


### PR DESCRIPTION
The [pytest-docs][1] mention this is for the pytest failure message:

> In the context manager form you may use the keyword argument `message` to
> specify a custom failure message

[1]: https://docs.pytest.org/en/latest/assert.html#assertions-about-expected-exceptions